### PR TITLE
Add default Repository implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ coverage-ci:
 
 coverage-html:
 	@$(GOPATHCMD) go tool cover -html="${COVERAGEFILE}" -o .cover/report.html
+	@xdg-open .cover/report.html 2> /dev/null > /dev/null
 
 dep-add:
 ifdef PACKAGE

--- a/count.go
+++ b/count.go
@@ -2,7 +2,7 @@ package repository
 
 import "github.com/globalsign/mgo"
 
-func Count(r Repository, params ...interface{}) (n int, err error) {
+func Count(r RepositoryProvider, params ...interface{}) (n int, err error) {
 	err = r.GetQueryRunner().RunWithDB(func(db *mgo.Database) error {
 		query, err := Query(r, db.C(r.GetCollectionName()), params...)
 		if err != nil {

--- a/count_and_find.go
+++ b/count_and_find.go
@@ -4,7 +4,7 @@ import (
 	"github.com/globalsign/mgo"
 )
 
-func CountAndFindAll(r Repository, dst interface{}, params ...interface{}) (n int, err error) {
+func CountAndFindAll(r RepositoryProvider, dst interface{}, params ...interface{}) (n int, err error) {
 	err = r.GetQueryRunner().RunWithDB(func(db *mgo.Database) error {
 		query, count, err := CountAndQuery(r, db.C(r.GetCollectionName()), params...)
 		if err != nil {

--- a/count_and_find_test.go
+++ b/count_and_find_test.go
@@ -11,6 +11,22 @@ var _ = Describe("CountAndFind", func() {
 		Expect(clearSession()).To(BeNil())
 	})
 
+	It("should find all objects (default repository)", func() {
+		r := NewRepository()
+		insertObjects(r)
+		objs := make([]testRepObject, 0)
+		count, err := r.CountAndFindAll(&objs)
+		Expect(err).To(BeNil())
+		Expect(count).To(Equal(3))
+		Expect(objs).To(HaveLen(3))
+		Expect(objs[0].Name).To(Equal("Snake Eyes"))
+		Expect(objs[0].Age).To(Equal(33))
+		Expect(objs[1].Name).To(Equal("Scarlett"))
+		Expect(objs[1].Age).To(Equal(22))
+		Expect(objs[2].Name).To(Equal("Duke"))
+		Expect(objs[2].Age).To(Equal(22))
+	})
+
 	It("should find all objects", func() {
 		r := &testRepNoDefaultCriteriaNoDefaultSorting{}
 		insertObjects(r)

--- a/count_test.go
+++ b/count_test.go
@@ -11,6 +11,14 @@ var _ = Describe("Count", func() {
 		Expect(clearSession()).To(BeNil())
 	})
 
+	It("should count all objects (default repository)", func() {
+		r := NewRepository()
+		insertObjects(r)
+		count, err := r.Count()
+		Expect(err).To(BeNil())
+		Expect(count).To(Equal(3))
+	})
+
 	It("should count all objects", func() {
 		r := &testRepNoDefaultCriteriaNoDefaultSorting{}
 		insertObjects(r)

--- a/create.go
+++ b/create.go
@@ -2,7 +2,7 @@ package repository
 
 import "github.com/globalsign/mgo"
 
-func Create(r Repository, object interface{}) error {
+func Create(r RepositoryProvider, object interface{}) error {
 	return r.GetQueryRunner().RunWithDB(func(db *mgo.Database) error {
 		return db.C(r.GetCollectionName()).Insert(object)
 	})

--- a/create_test.go
+++ b/create_test.go
@@ -13,6 +13,25 @@ var _ = Describe("Create", func() {
 		Expect(clearSession()).To(BeNil())
 	})
 
+	It("should create an object (default repository)", func() {
+		r := NewRepository()
+		err := r.Create(testRepObject{
+			ID:   bson.NewObjectId(),
+			Name: "Snake Eyes",
+			Age:  33,
+		})
+		Expect(err).To(BeNil())
+		Expect(defaultQueryRunner.RunWithDB(func(db *mgo.Database) error {
+			c := db.C(r.GetCollectionName())
+			objs := make([]testRepObject, 0)
+			Expect(c.Find(nil).All(&objs)).To(BeNil())
+			Expect(objs).To(HaveLen(1))
+			Expect(objs[0].Name).To(Equal("Snake Eyes"))
+			Expect(objs[0].Age).To(Equal(33))
+			return nil
+		})).To(BeNil())
+	})
+
 	It("should create an object", func() {
 		r := &testRepNoDefaultCriteriaNoDefaultSorting{}
 		err := repository.Create(r, testRepObject{

--- a/delete.go
+++ b/delete.go
@@ -2,7 +2,7 @@ package repository
 
 import "github.com/globalsign/mgo"
 
-func Delete(r Repository, params ...interface{}) error {
+func Delete(r RepositoryProvider, params ...interface{}) error {
 	return r.GetQueryRunner().RunWithDB(func(db *mgo.Database) error {
 		c := db.C(r.GetCollectionName())
 		criteria, err := GetQueryCriteria(r.GetDefaultCriteria(), params...)

--- a/delete_all.go
+++ b/delete_all.go
@@ -2,7 +2,7 @@ package repository
 
 import "github.com/globalsign/mgo"
 
-func DeleteAll(r Repository, params ...interface{}) (n int, resultErr error) {
+func DeleteAll(r RepositoryProvider, params ...interface{}) (n int, resultErr error) {
 	resultErr = r.GetQueryRunner().RunWithDB(func(db *mgo.Database) error {
 		c := db.C(r.GetCollectionName())
 		criteria, err := GetQueryCriteria(r.GetDefaultCriteria(), params...)

--- a/delete_all_test.go
+++ b/delete_all_test.go
@@ -11,6 +11,19 @@ var _ = Describe("DeleteAll", func() {
 		Expect(clearSession()).To(BeNil())
 	})
 
+	It("should delete an object (default repository)", func() {
+		r := NewRepository()
+		_, objid2, _ := insertObjects(r)
+		deleted, err := r.DeleteAll(repository.ByID(objid2))
+		Expect(err).To(BeNil())
+		objs := make([]testRepObject, 0)
+		Expect(r.FindAll(&objs)).To(BeNil())
+		Expect(deleted).To(Equal(1))
+		Expect(objs).To(HaveLen(2))
+		Expect(objs[0].Name).To(Equal("Snake Eyes"))
+		Expect(objs[1].Name).To(Equal("Duke"))
+	})
+
 	It("should delete an object", func() {
 		r := &testRepNoDefaultCriteriaNoDefaultSorting{}
 		_, objid2, _ := insertObjects(r)

--- a/delete_test.go
+++ b/delete_test.go
@@ -12,6 +12,21 @@ var _ = Describe("Delete", func() {
 		Expect(clearSession()).To(BeNil())
 	})
 
+	It("should delete an object (default repository)", func() {
+		r := NewRepository()
+		tobj := &testRepObject{
+			ID:   bson.NewObjectId(),
+			Name: "Snake Eyes",
+			Age:  33,
+		}
+		err := r.Create(tobj)
+		Expect(err).To(BeNil())
+		Expect(r.Delete(repository.WithCriteria(repository.EQ("name", "Snake Eyes")))).To(BeNil())
+		objs := make([]testRepObject, 0)
+		Expect(r.FindAll(&objs)).To(BeNil())
+		Expect(objs).To(BeEmpty())
+	})
+
 	It("should delete an object", func() {
 		r := &testRepNoDefaultCriteriaNoDefaultSorting{}
 		tobj := &testRepObject{

--- a/example_test.go
+++ b/example_test.go
@@ -80,7 +80,7 @@ func (rep *testRepNoDefaultCriteriaWithDefaultSorting) GetDefaultSorting() []str
 	return []string{"age"}
 }
 
-func createIndexes(r repository.Repository) {
+func createIndexes(r repository.RepositoryProvider) {
 	index := mgo.Index{
 		Key: []string{"$text:name"},
 	}
@@ -89,7 +89,7 @@ func createIndexes(r repository.Repository) {
 	})).To(BeNil())
 }
 
-func insertObjects(r repository.Repository) (bson.ObjectId, bson.ObjectId, bson.ObjectId) {
+func insertObjects(r repository.RepositoryProvider) (bson.ObjectId, bson.ObjectId, bson.ObjectId) {
 	objid1, objid2, objid3 := bson.NewObjectId(), bson.NewObjectId(), bson.NewObjectId()
 
 	Expect(repository.Create(r, &testRepObject{

--- a/example_test.go
+++ b/example_test.go
@@ -23,6 +23,13 @@ type testRepObject struct {
 	Details  []bson.M      `bson:"details,omitempty"`
 }
 
+func NewRepository() *repository.Repository {
+	return repository.NewRepository(repository.RepositoryConfig{
+		Collection:  "collection",
+		QueryRunner: defaultQueryRunner,
+	})
+}
+
 type testRepNoDefaultCriteriaNoDefaultSorting struct {
 }
 

--- a/find.go
+++ b/find.go
@@ -4,7 +4,7 @@ import (
 	"github.com/globalsign/mgo"
 )
 
-func Find(r Repository, dst interface{}, params ...interface{}) error {
+func Find(r RepositoryProvider, dst interface{}, params ...interface{}) error {
 	return r.GetQueryRunner().RunWithDB(func(db *mgo.Database) error {
 		query, err := Query(r, db.C(r.GetCollectionName()), params...)
 		if err != nil {

--- a/find_all.go
+++ b/find_all.go
@@ -4,7 +4,7 @@ import (
 	"github.com/globalsign/mgo"
 )
 
-func FindAll(r Repository, objects interface{}, params ...interface{}) error {
+func FindAll(r RepositoryProvider, objects interface{}, params ...interface{}) error {
 	return r.GetQueryRunner().RunWithDB(func(db *mgo.Database) error {
 		query, err := Query(r, db.C(r.GetCollectionName()), params...)
 		if err != nil {

--- a/find_all_test.go
+++ b/find_all_test.go
@@ -12,6 +12,20 @@ var _ = Describe("FindAll", func() {
 		Expect(clearSession()).To(BeNil())
 	})
 
+	It("should find all objects (default repository)", func() {
+		r := NewRepository()
+		insertObjects(r)
+		objs := make([]testRepObject, 0)
+		Expect(r.FindAll(&objs)).To(BeNil())
+		Expect(objs).To(HaveLen(3))
+		Expect(objs[0].Name).To(Equal("Snake Eyes"))
+		Expect(objs[0].Age).To(Equal(33))
+		Expect(objs[1].Name).To(Equal("Scarlett"))
+		Expect(objs[1].Age).To(Equal(22))
+		Expect(objs[2].Name).To(Equal("Duke"))
+		Expect(objs[2].Age).To(Equal(22))
+	})
+
 	It("should find all objects", func() {
 		r := &testRepNoDefaultCriteriaNoDefaultSorting{}
 		insertObjects(r)

--- a/find_by_id.go
+++ b/find_by_id.go
@@ -11,7 +11,7 @@ import (
 // defaultCriteria.
 //
 // If no model is found, it returns an `mgo.ErrNotFound`.
-func FindByID(r Repository, id interface{}, dst interface{}, params ...interface{}) error {
+func FindByID(r RepositoryProvider, id interface{}, dst interface{}, params ...interface{}) error {
 	return r.GetQueryRunner().RunWithDB(func(db *mgo.Database) error {
 		query, err := Query(r, db.C(r.GetCollectionName()), append([]interface{}{
 			&Criteria{

--- a/find_by_id_test.go
+++ b/find_by_id_test.go
@@ -13,6 +13,15 @@ var _ = Describe("FindByID", func() {
 		Expect(clearSession()).To(BeNil())
 	})
 
+	It("should find an object by id (default repository)", func() {
+		r := NewRepository()
+		objid1, _, _ := insertObjects(r)
+		var obj testRepObject
+		Expect(r.FindByID(objid1, &obj)).To(BeNil())
+		Expect(obj.Name).To(Equal("Snake Eyes"))
+		Expect(obj.Age).To(Equal(33))
+	})
+
 	It("should find an object by id", func() {
 		r := &testRepNoDefaultCriteriaNoDefaultSorting{}
 		objid1, _, _ := insertObjects(r)

--- a/find_test.go
+++ b/find_test.go
@@ -13,6 +13,19 @@ var _ = Describe("Find", func() {
 		Expect(clearSession()).To(BeNil())
 	})
 
+	It("should find an object by name (default repository)", func() {
+		r := NewRepository()
+		tobj := &testRepObject{
+			ID:   bson.NewObjectId(),
+			Name: "Snake Eyes",
+			Age:  33,
+		}
+		err := r.Create(tobj)
+		Expect(err).To(BeNil())
+		var obj testRepObject
+		Expect(r.Find(&obj, repository.WithCriteria(repository.EQ("name", "Snake Eyes")))).To(BeNil())
+	})
+
 	It("should find an object by name", func() {
 		r := &testRepNoDefaultCriteriaNoDefaultSorting{}
 		tobj := &testRepObject{

--- a/query.go
+++ b/query.go
@@ -91,7 +91,7 @@ func GetQueryCriteria(defaultCriteria interface{}, params ...interface{}) (bson.
 	return ccc, nil
 }
 
-func ApplyQueryModifiers(r Repository, query *mgo.Query, params ...interface{}) (*mgo.Query, error) {
+func ApplyQueryModifiers(r RepositoryProvider, query *mgo.Query, params ...interface{}) (*mgo.Query, error) {
 	var sorting = r.GetDefaultSorting()
 	for _, param := range params {
 		switch v := param.(type) {
@@ -104,13 +104,8 @@ func ApplyQueryModifiers(r Repository, query *mgo.Query, params ...interface{}) 
 			// building the conditions to bootstrap the `mgo.Query` object.
 			break
 		case *Sort:
-			// For sorting it has a special case: it will aggregate all sortings
-			// for a late modification.
-			if sorting == nil {
-				sorting = v.Fields
-			} else {
-				sorting = append(sorting, v.Fields...)
-			}
+			// For sorting it has a special case: it will replace the default sorting.
+			sorting = v.Fields
 			break
 		case QueryModifier:
 			// Queryable objects will apply some transformation to the query.
@@ -140,7 +135,7 @@ func ApplyQueryModifiers(r Repository, query *mgo.Query, params ...interface{}) 
 // passed as param.
 //
 // Finally, it will return the `mgo.Query` prepared for execution.
-func Query(r Repository, c *mgo.Collection, params ...interface{}) (*mgo.Query, error) {
+func Query(r RepositoryProvider, c *mgo.Collection, params ...interface{}) (*mgo.Query, error) {
 	conditions, err := GetQueryCriteria(r.GetDefaultCriteria(), params...)
 	if err != nil {
 		return nil, err
@@ -156,7 +151,7 @@ func Query(r Repository, c *mgo.Collection, params ...interface{}) (*mgo.Query, 
 // CountAndQuery will use the same idea as `Query`. However, before applying the
 // modifications from `QueryModifier` it saves the count and returns it with the
 // reference of the `mgo.Query` obtained.
-func CountAndQuery(r Repository, c *mgo.Collection, params ...interface{}) (*mgo.Query, int, error) {
+func CountAndQuery(r RepositoryProvider, c *mgo.Collection, params ...interface{}) (*mgo.Query, int, error) {
 	conditions, err := GetQueryCriteria(r.GetDefaultCriteria(), params...)
 	if err != nil {
 		return nil, 0, err

--- a/repository.go
+++ b/repository.go
@@ -1,8 +1,47 @@
 package repository
 
-type Repository interface {
+type RepositoryProvider interface {
 	GetCollectionName() string
 	GetQueryRunner() QueryRunner
 	GetDefaultCriteria() interface{}
 	GetDefaultSorting() []string
+}
+
+type Repository struct {
+	collection      string
+	runner          QueryRunner
+	defaultCriteria interface{}
+	defaultSorting  []string
+}
+
+type RepositoryConfig struct {
+	Collection      string
+	QueryRunner     QueryRunner
+	DefaultCriteria interface{}
+	DefaultSorting  []string
+}
+
+func NewRepository(config RepositoryConfig) *Repository {
+	return &Repository{
+		collection:      config.Collection,
+		runner:          config.QueryRunner,
+		defaultCriteria: config.DefaultCriteria,
+		defaultSorting:  config.DefaultSorting,
+	}
+}
+
+func (r *Repository) GetCollectionName() string {
+	return r.collection
+}
+
+func (r *Repository) GetQueryRunner() QueryRunner {
+	return r.runner
+}
+
+func (r *Repository) GetDefaultCriteria() interface{} {
+	return r.defaultCriteria
+}
+
+func (r *Repository) GetDefaultSorting() []string {
+	return r.defaultSorting
 }

--- a/repository.go
+++ b/repository.go
@@ -45,3 +45,55 @@ func (r *Repository) GetDefaultCriteria() interface{} {
 func (r *Repository) GetDefaultSorting() []string {
 	return r.defaultSorting
 }
+
+func (r *Repository) CountAndFindAll(dst interface{}, params ...interface{}) (n int, err error) {
+	return CountAndFindAll(r, dst, params...)
+}
+
+func (r *Repository) Count(params ...interface{}) (n int, err error) {
+	return Count(r, params...)
+}
+
+func (r *Repository) Create(object interface{}) error {
+	return Create(r, object)
+}
+
+func (r *Repository) DeleteAll(params ...interface{}) (n int, resultErr error) {
+	return DeleteAll(r, params...)
+}
+
+func (r *Repository) Delete(params ...interface{}) error {
+	return Delete(r, params...)
+}
+
+func (r *Repository) FindAll(objects interface{}, params ...interface{}) error {
+	return FindAll(r, objects, params...)
+}
+
+func (r *Repository) FindByID(id interface{}, dst interface{}, params ...interface{}) error {
+	return FindByID(r, id, dst, params...)
+}
+
+func (r *Repository) Find(dst interface{}, params ...interface{}) error {
+	return Find(r, dst, params...)
+}
+
+func (r *Repository) UpdateRawWithCriteria(object interface{}, selector ...interface{}) error {
+	return UpdateRawWithCriteria(r, object, selector...)
+}
+
+func (r *Repository) UpdateAndFind(id interface{}, dst interface{}, object interface{}, params ...interface{}) error {
+	return UpdateAndFind(r, id, dst, object, params...)
+}
+
+func (r *Repository) Update(id interface{}, object interface{}) error {
+	return Update(r, id, object)
+}
+
+func (r *Repository) UpdateRaw(id interface{}, object interface{}) error {
+	return UpdateRaw(r, id, object)
+}
+
+func (r *Repository) Upsert(object interface{}, selector ...interface{}) error {
+	return Upsert(r, object, selector...)
+}

--- a/update.go
+++ b/update.go
@@ -6,7 +6,7 @@ import (
 )
 
 // UpdateAndFind does an update and returns the updated model.
-func UpdateAndFind(r Repository, id interface{}, dst interface{}, object interface{}, params ...interface{}) error {
+func UpdateAndFind(r RepositoryProvider, id interface{}, dst interface{}, object interface{}, params ...interface{}) error {
 	return r.GetQueryRunner().RunWithDB(func(db *mgo.Database) error {
 		params = append(params, ByID(id))
 
@@ -26,7 +26,7 @@ func UpdateAndFind(r Repository, id interface{}, dst interface{}, object interfa
 }
 
 // Update does a complete update of a model.
-func Update(r Repository, id interface{}, object interface{}) error {
+func Update(r RepositoryProvider, id interface{}, object interface{}) error {
 	return r.GetQueryRunner().RunWithDB(func(db *mgo.Database) error {
 		return db.C(r.GetCollectionName()).Update(bson.D{
 			bson.DocElem{
@@ -39,7 +39,7 @@ func Update(r Repository, id interface{}, object interface{}) error {
 }
 
 // UpdateRaw does a complete update of a model.
-func UpdateRaw(r Repository, id interface{}, object interface{}) error {
+func UpdateRaw(r RepositoryProvider, id interface{}, object interface{}) error {
 	return r.GetQueryRunner().RunWithDB(func(db *mgo.Database) error {
 		return db.C(r.GetCollectionName()).Update(
 			bson.D{

--- a/update_raw_with_criteria.go
+++ b/update_raw_with_criteria.go
@@ -5,7 +5,7 @@ import (
 )
 
 // UpdateRawWithCriteria does a update of a model based on any selector.
-func UpdateRawWithCriteria(r Repository, object interface{}, selector ...interface{}) error {
+func UpdateRawWithCriteria(r RepositoryProvider, object interface{}, selector ...interface{}) error {
 	return r.GetQueryRunner().RunWithDB(func(db *mgo.Database) error {
 		criteria, err := GetQueryCriteria(r.GetDefaultCriteria(), selector...)
 		if err != nil {

--- a/update_raw_with_criteria_test.go
+++ b/update_raw_with_criteria_test.go
@@ -13,6 +13,34 @@ var _ = Describe("UpdateRawWithCriteria", func() {
 		Expect(clearSession()).To(BeNil())
 	})
 
+	It("should update an object by one field (default repository)", func() {
+		r := NewRepository()
+		obj := &testRepObject{
+			ID:   bson.NewObjectId(),
+			Name: "Snake Eyes",
+			Age:  33,
+		}
+		Expect(r.Create(obj)).To(BeNil())
+		Expect(r.UpdateRawWithCriteria(
+			bson.M{
+				"$set": testRepObject{
+					ID:   obj.ID,
+					Name: "Scarlett",
+					Age:  22,
+				},
+			}, repository.EQ("name", "Snake Eyes"),
+		)).To(BeNil())
+		Expect(defaultQueryRunner.RunWithDB(func(db *mgo.Database) error {
+			c := db.C(r.GetCollectionName())
+			objs := make([]testRepObject, 0)
+			Expect(c.Find(nil).All(&objs)).To(BeNil())
+			Expect(objs).To(HaveLen(1))
+			Expect(objs[0].Name).To(Equal("Scarlett"))
+			Expect(objs[0].Age).To(Equal(22))
+			return nil
+		})).To(BeNil())
+	})
+
 	It("should update an object by one field", func() {
 		r := &testRepNoDefaultCriteriaNoDefaultSorting{}
 		obj := &testRepObject{
@@ -194,7 +222,7 @@ var _ = Describe("UpdateRawWithCriteria", func() {
 			},
 			map[string]interface{}{
 				"_id": obj.ID,
-			}, )).To(BeNil())
+			})).To(BeNil())
 		Expect(defaultQueryRunner.RunWithDB(func(db *mgo.Database) error {
 			c := db.C(r.GetCollectionName())
 			objs := make([]testRepObject, 0)

--- a/upsert.go
+++ b/upsert.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Upsert find a single document, if matching update else create.
-func Upsert(r Repository, object interface{}, selector ...interface{}) error {
+func Upsert(r RepositoryProvider, object interface{}, selector ...interface{}) error {
 	return r.GetQueryRunner().RunWithDB(func(db *mgo.Database) error {
 		criteria, err := GetQueryCriteria(r.GetDefaultCriteria(), selector...)
 		if err != nil {

--- a/upsert_test.go
+++ b/upsert_test.go
@@ -13,6 +13,25 @@ var _ = Describe("Upsert", func() {
 		Expect(clearSession()).To(BeNil())
 	})
 
+	It("should create an object by one field (default repository)", func() {
+		r := NewRepository()
+		obj := &testRepObject{
+			Name: "Snake Eyes",
+			Age:  33,
+		}
+
+		Expect(r.Upsert(obj)).To(BeNil())
+		Expect(defaultQueryRunner.RunWithDB(func(db *mgo.Database) error {
+			c := db.C(r.GetCollectionName())
+			objs := make([]testRepObject, 0)
+			Expect(c.Find(nil).All(&objs)).To(BeNil())
+			Expect(objs).To(HaveLen(1))
+			Expect(objs[0].Name).To(Equal("Snake Eyes"))
+			Expect(objs[0].Age).To(Equal(33))
+			return nil
+		})).To(BeNil())
+	})
+
 	It("should create an object by one field", func() {
 		r := &testRepNoDefaultCriteriaNoDefaultSorting{}
 		obj := &testRepObject{


### PR DESCRIPTION
This PR enables the following:

```go
usersRepo := repository.NewRepository{
  Collection:  "users",
  QueryRunner: &myQueryRunner,
}

usersRepo.Create(&models.User{
  ID: 1,
  Name: "Snake Eyes"
})
```

The current API stays the same. Only `Repository` interface is now called `RepositoryProvider`.

Another change is the `GetDefaultSorting` behavior: any sorting passed during queries will now override the default, instead of aggregate.